### PR TITLE
接口变更

### DIFF
--- a/aliyunpan/file_directory.go
+++ b/aliyunpan/file_directory.go
@@ -317,7 +317,7 @@ func (p *PanClient) fileListReq(param *FileListParam) (*fileListResult, *apierro
 	}
 
 	fullUrl := &strings.Builder{}
-	fmt.Fprintf(fullUrl, "%s/v2/file/list", API_URL)
+	fmt.Fprintf(fullUrl, "%s/adrive/v3/file/list", API_URL)
 	logger.Verboseln("do request url: " + fullUrl.String())
 
 	pFileId := param.ParentFileId


### PR DESCRIPTION
`/v2/file/list`地址貌似失效了?
不太确定,我改了下地址`/adrive/v3/file/list`测了下貌似没问题

不太清楚是不是阿里下线了这个api

https://github.com/tickstep/aliyunpan-api/blob/1e1c1fec1b9e6f8c540a53e9b31a94d993eadd42/aliyunpan/file_directory.go#L320
